### PR TITLE
Proxy for any target

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,10 @@ proxyServer.listen(8015);
  *  **secure**: true/false, if you want to verify the SSL Certs
  *  **xfwd**: true/false, adds x-forward headers
  *  **toProxy**: passes the absolute URL as the `path` (useful for proxying to proxies)
- *  **hostRewrite**: rewrites the location hostname on (301/302/307/308) redirects.
+ *  **prependPath**: specify whether you want to prepend the target's path to the proxy path
+ *  **localAddress**: Local interface string to bind for outgoing connections
+ *  **changeOrigin**: changes the origin of the host header to the target URL
+ *  **hostRewrite**: rewrites the location hostname on (301/302/307/308) redirects
 
 If you are using the `proxyServer.listen` method, the following options are also applicable:
 

--- a/lib/http-proxy.js
+++ b/lib/http-proxy.js
@@ -45,8 +45,8 @@ module.exports.createProxyServer =
    *  }
    *
    *  NOTE: `options.ws` and `options.ssl` are optional.
-   *    `options.target and `options.forward` cannot be
-   *    both missing
+   *    If neither `options.target` nor `options.forward` is given,
+   *    then any target server may be proxies.
    *  }
    */
 

--- a/lib/http-proxy/index.js
+++ b/lib/http-proxy/index.js
@@ -59,6 +59,11 @@ function createRightProxy(type) {
 
       /* optional args parse end */
 
+      if (!options.target && !options.forward) {
+        options.target = req.url;
+        options.prependPath = false;
+      }
+
       ['target', 'forward'].forEach(function(e) {
         if (typeof options[e] === 'string')
           options[e] = parse_url(options[e]);


### PR DESCRIPTION
It would be nice if one could easily use the module to proxy not just for one target, but for any target the incoming connection requests. I.e. do normal web cache behaviour, not reverse proxying. Here is a setup to do so. Since several examples in the README use `{}` as the configuration, i.e. without `target` or `forward` setting, these examples will currently fail. With my addition, they will work and simply forward the requests.

Perhaps you might want to make people aware that proxying without a fixed target and without a bind restriction to localhost, any incoming request might query pages from the local LAN or even localhost. Depending on configuration, that may or may not be a security issue. If you consider this an issue, write examples in such a way that copying them will work (or fail due to an invented domain name) but will not cause such security problems.
