### PR TITLE
Fixes issues with incorrect port selection

### DIFF
--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -31,7 +31,8 @@ common.isSSL = isSSL;
  */
 
 common.setupOutgoing = function(outgoing, options, req, forward) {
-  outgoing.port = options[forward || 'target'].port ||
+  outgoing.port = options.port || 
+                  options[forward || 'target'].port ||
                   (isSSL.test(options[forward || 'target'].protocol) ? 443 : 80);
 
   ['host', 'hostname', 'socketPath', 'pfx', 'key',

--- a/test/lib-http-proxy-common-test.js
+++ b/test/lib-http-proxy-common-test.js
@@ -164,6 +164,15 @@ describe('lib/http-proxy/common.js', function () {
       expect(outgoing.port).to.eql(443);
     });
 
+    it('should set outgoing port to one specified', function () {
+      var outgoing = {};
+      common.setupOutgoing(outgoing, {
+        target: url.parse('https://sometarget.com'),
+        port: 1234
+      }, { url: '/' });
+      expect(outgoing.port).to.eql(1234);
+    });
+
     it('should keep the original target path in the outgoing path', function(){
       var outgoing = {};
       common.setupOutgoing(outgoing, {target:


### PR DESCRIPTION
Hey everyone,

This is in regards to an issue I brought up in #915 yesterday.  I was having an issue with incorrect port selection and assumed @BadBoy20 might be having the issue too.  Anyhow, the problem for me was explicit declaration of the port was not taking precedence over the port implied by the protocol.  The unit test I created was failing before I made the fix.  Also, I did not check the getPort() function in common.js as it’s only purpose is setting “x-forwarded” headers in web-incoming.js and ws-incoming.js so it seemed out of scope for this issue.

Cheers.
