### PR TITLE
when the request come back to 404 ,request the next option

### DIFF
--- a/lib/http-proxy.js
+++ b/lib/http-proxy.js
@@ -54,7 +54,7 @@ module.exports.createProxyServer =
    *    both missing
    *  }
    */
-    let op
+    var op
     if (util.isArray(options)) {
         op = options.shift()
         httpProxy.Server.options = options

--- a/lib/http-proxy.js
+++ b/lib/http-proxy.js
@@ -1,6 +1,7 @@
 var http      = require('http'),
     https     = require('https'),
     url       = require('url'),
+    util      = require('util'),
     httpProxy = require('./http-proxy/');
 
 /**
@@ -53,7 +54,11 @@ module.exports.createProxyServer =
    *    both missing
    *  }
    */
-
-  return new httpProxy.Server(options);
+    let op
+    if (util.isArray(options)) {
+        op = options.shift()
+        httpProxy.Server.options = options
+    }
+    return new httpProxy.Server(op || options);
 };
 

--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -153,6 +153,14 @@ web_o = Object.keys(web_o).map(function(pass) {
 
     proxyReq.on('response', function(proxyRes) {
       if(server) { server.emit('proxyRes', proxyRes, req, res); }
+
+      if(proxyRes.statusCode === 404){
+        const _httpProxy = require('../../http-proxy.js')
+        let rap = _httpProxy.createProxyServer(_httpProxy.options)
+        rap.web(req,res)
+        return null
+      }
+
       for(var i=0; i < web_o.length; i++) {
         if(web_o[i](req, res, proxyRes, options)) { break; }
       }

--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -153,9 +153,9 @@ web_o = Object.keys(web_o).map(function(pass) {
 
     proxyReq.on('response', function(proxyRes) {
       if(server) { server.emit('proxyRes', proxyRes, req, res); }
-
-      if(proxyRes.statusCode === 404){
-        const _httpProxy = require('../../http-proxy.js')
+      const _httpProxy = require('../../http-proxy.js')
+      if(proxyRes.statusCode === 404 || _httpProxy.length > 0){
+        
         let rap = _httpProxy.createProxyServer(_httpProxy.options)
         rap.web(req,res)
         return null

--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -153,10 +153,10 @@ web_o = Object.keys(web_o).map(function(pass) {
 
     proxyReq.on('response', function(proxyRes) {
       if(server) { server.emit('proxyRes', proxyRes, req, res); }
-      const _httpProxy = require('../../http-proxy.js')
+      var _httpProxy = require('../../http-proxy.js')
       if(proxyRes.statusCode === 404 || _httpProxy.length > 0){
         
-        let rap = _httpProxy.createProxyServer(_httpProxy.options)
+        var rap = _httpProxy.createProxyServer(_httpProxy.options)
         rap.web(req,res)
         return null
       }

--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -154,7 +154,7 @@ web_o = Object.keys(web_o).map(function(pass) {
     proxyReq.on('response', function(proxyRes) {
       if(server) { server.emit('proxyRes', proxyRes, req, res); }
       var _httpProxy = require('../../http-proxy.js')
-      if(proxyRes.statusCode === 404 || _httpProxy.length > 0){
+      if(proxyRes.statusCode === 404 && _httpProxy.options.length > 0){
         
         var rap = _httpProxy.createProxyServer(_httpProxy.options)
         rap.web(req,res)


### PR DESCRIPTION
can use like this:

let proxy = httpProxy.createProxyServer(
  [
    {
      target: proxyConfig.apiHost,
      // see https://github.com/nodejitsu/node-http-proxy#options
      changeOrigin: true
    },
    {
      target: proxyConfig.rapHost,
      // see https://github.com/nodejitsu/node-http-proxy#options
      changeOrigin: true
    }
  ]
)
