### PR TITLE
Fix incorrect target name for reverse proxy example

### DIFF
--- a/examples/http/reverse-proxy.js
+++ b/examples/http/reverse-proxy.js
@@ -31,8 +31,9 @@ var proxy = httpProxy.createServer();
 
 var server = http.createServer(function (req, res) {
   util.puts('Receiving reverse proxy request for:' + req.url);
-
-  proxy.web(req, res, {target: req.url, secure: false});
+  var parsedUrl = url.parse(req.url);
+  var target = parsedUrl.protocol + '//' + parsedUrl.hostname;
+  proxy.web(req, res, {target: target, secure: false});
 }).listen(8213);
 
 server.on('connect', function (req, socket) {


### PR DESCRIPTION
If we set `target:req.url`, request to http://localhost/favicon.ico would be mapped to  http://localhost/favicon.ico/favicon.ico

This PR changes `target` to make it equal destination host authority