### PR TITLE
Fix modify response middleware example

### DIFF
--- a/examples/middleware/modifyResponse-middleware.js
+++ b/examples/middleware/modifyResponse-middleware.js
@@ -34,6 +34,20 @@ var util = require('util'),
 //
 // Basic Connect App
 //
+app.use(function (req, res, next) {
+  var _write = res.write;
+
+  res.write = function (data) {
+    _write.call(res, data.toString().replace("Ruby", "nodejitsu"));
+  }
+  next();
+});
+
+app.use(function (req, res) {
+  proxy.web(req, res)
+});
+
+http.createServer(app).listen(8013);
 
 //
 // Basic Http Proxy Server

--- a/examples/middleware/modifyResponse-middleware.js
+++ b/examples/middleware/modifyResponse-middleware.js
@@ -28,6 +28,7 @@ var util = require('util'),
     colors = require('colors'),
     http = require('http'),
     connect = require('connect'),
+    app = connect(),
     httpProxy = require('../../lib/http-proxy');
 
 //

--- a/examples/middleware/modifyResponse-middleware.js
+++ b/examples/middleware/modifyResponse-middleware.js
@@ -34,19 +34,6 @@ var util = require('util'),
 //
 // Basic Connect App
 //
-connect.createServer(
-  function (req, res, next) {
-    var _write = res.write;
-
-    res.write = function (data) {
-      _write.call(res, data.toString().replace("Ruby", "nodejitsu"));
-    }
-    next();
-  },
-  function (req, res) {
-    proxy.web(req, res);
-  }
-).listen(8013);
 
 //
 // Basic Http Proxy Server


### PR DESCRIPTION
This PR simply fixes the modifyResponse-middleware example to work properly by removing a deprecated function call (connect.createServer()) and passing the middleware functions to an http server.