### PR TITLE
Set incoming requesting timeout

### DIFF
--- a/lib/http-proxy/index.js
+++ b/lib/http-proxy/index.js
@@ -68,6 +68,11 @@ function createRightProxy(type) {
         return this.emit('error', new Error('Must provide a proper URL as target'));
       }
 
+      // ensure request don't timeout before the target's configured timeout
+      if (options.proxyTimeout) {
+        req.setTimeout(options.proxyTimeout);
+      }
+
       for(var i=0; i < passes.length; i++) {
         /**
          * Call of passes functions


### PR DESCRIPTION
This ensures the incoming request does not timeout before the target's timeout configured with `options.proxyTimeout`.

As I'm not familiar to the code base, I struggled seeing the best entry to write a test for this. Any thoughts would be appreciated.

Fixes https://github.com/nodejitsu/node-http-proxy/issues/1113

~~**Edit:** I'm looking into the existing timeout test failing~~