### PR TITLE
Add option to remove the 'secure' attribute from cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ proxyServer.listen(8015);
        "*": ""
      }
      ```
+*  **cookieRemoveSecure**: true/false, Default: false - removes the `secure` attribute from cookies so they can be used by non-HTTPS origins
 *  **headers**: object with extra headers to be added to target requests.
 *  **proxyTimeout**: timeout (in millis) for outgoing proxy requests
 *  **timeout**: timeout (in millis) for incoming requests

--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -237,6 +237,24 @@ common.rewriteCookieProperty = function rewriteCookieProperty(header, config, pr
 };
 
 /**
+ * Removes the specified attribute from a cookie header.
+ *
+ * @param {String|Array} Header
+ * @param {String} Property Name of attribute to remove
+ *
+ * @api private
+ */
+common.removeCookieProperty = function removeCookieProperty(header, property) {
+  if (Array.isArray(header)) {
+    return header.map(function (headerElement) {
+      return removeCookieProperty(headerElement, property);
+    });
+  }
+  // Intentionally not checking for "=" to catch directives with no value (eg "; secure").
+  return header.replace(new RegExp(';\\s*' + property + '[^;]*', 'i'), '');
+};
+
+/**
  * Check the host and see if it potentially has a port in it (keep it simple)
  *
  * @returns {Boolean} Whether we have one or not

--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -95,6 +95,9 @@ module.exports = { // <--
           if (rewriteCookiePathConfig && key.toLowerCase() === 'set-cookie') {
             header = common.rewriteCookieProperty(header, rewriteCookiePathConfig, 'path');
           }
+          if (options.cookieRemoveSecure && key.toLowerCase() === 'set-cookie') {
+            header = common.removeCookieProperty(header, 'secure');
+          }
           res.setHeader(String(key).trim(), header);
         };
 

--- a/test/lib-http-proxy-passes-web-outgoing-test.js
+++ b/test/lib-http-proxy-passes-web-outgoing-test.js
@@ -235,7 +235,7 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
           how: 'are you?',
           'set-cookie': [
             'hello; domain=my.domain; path=/',
-            'there; domain=my.domain; path=/'
+            'there; domain=my.domain; path=/; secure'
           ]
         }
       };
@@ -403,6 +403,26 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
         .to.contain('hello-on-my.old.domain; domain=my.new.domain; path=/');
       expect(this.res.headers['set-cookie'])
         .to.contain('hello-on-my.special.domain; domain=my.special.domain; path=/');
+    });
+
+    it('does not remove `secure` attribute by default', function() {
+      var options = {};
+
+      httpProxy.writeHeaders({}, this.res, this.proxyRes, options);
+
+      expect(this.res.headers['set-cookie'])
+        .to.contain('there; domain=my.domain; path=/; secure');
+    });
+
+    it('removes `secure` attribute when cookieRemoveSecure true', function() {
+      var options = {
+        cookieRemoveSecure: true
+      };
+
+      httpProxy.writeHeaders({}, this.res, this.proxyRes, options);
+
+      expect(this.res.headers['set-cookie'])
+        .to.contain('there; domain=my.domain; path=/');
     });
   });
 


### PR DESCRIPTION
This allows cookies proxied from HTTPS sites to be used by a non-HTTPS localhost development environment.

A new `removeCookieProperty()` helper has been added since the existing `rewriteCookieProperty()`:
* can't handle attributes that have no value (since the regex expects an `=`, and changing that would break the current implemention)
* doesn't really make sense for outright removing an attribute regardless of any value

Fixes #1165.