### PR TITLE
x-forwarded-host overwrite for mutli level proxies

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -82,7 +82,7 @@ module.exports = {
         values[header];
     });
 
-    req.headers['x-forwarded-host'] = req.headers['host'] || '';
+    req.headers['x-forwarded-host'] = req.headers['x-forwarded-host'] || req.headers['host'] || '';
   },
 
   /**


### PR DESCRIPTION
Let's consider a scenario
 `proxy (Internet-facing) -> proxy(load balancer) -> application` where both proxies will be based on node-http-proxy, **with current logic original host to be lost**
With updated logic the original forwarded host will be passed down the proxy chain