### PR TITLE
feat: Add `mergeCookies` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,20 @@ proxyServer.listen(8015);
 
     };
     ```
+* **mergeCookies**: true/false, merges `set-cookie` header from a request passed to `httpProxy.web` and from response.
+  E.g.:
+  ```
+  const http = require("http");
+  const httpProxy = require("http-proxy");
+  const proxy = httpProxy.createProxyServer({});
+  
+  const gateway = http.createServer((req, res) => {
+    res.setHeader('set-cookie', ["gateway=true; Path=/"]);
+    proxy.web(req, res, {target: "http://localhost:3002"});
+  });
+  
+  gateway.listen(3003);
+  ```
 
 **NOTE:**
 `options.ws` and `options.ssl` are optional.

--- a/lib/http-proxy.js
+++ b/lib/http-proxy.js
@@ -40,6 +40,7 @@ function createProxyServer(options) {
    *    hostRewrite: rewrites the location hostname on (301/302/307/308) redirects, Default: null.
    *    autoRewrite: rewrites the location host/port on (301/302/307/308) redirects based on requested host/port. Default: false.
    *    protocolRewrite: rewrites the location protocol on (301/302/307/308) redirects to 'http' or 'https'. Default: null.
+   *    mergeCookies: allows to merge `set-cookie` headers from passed response and response from target
    *  }
    *
    *  NOTE: `options.ws` and `options.ssl` are optional.

--- a/lib/http-proxy/common.js
+++ b/lib/http-proxy/common.js
@@ -49,7 +49,7 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
   if (options.auth) {
     outgoing.auth = options.auth;
   }
-  
+
   if (options.ca) {
       outgoing.ca = options.ca;
   }
@@ -234,6 +234,30 @@ common.rewriteCookieProperty = function rewriteCookieProperty(header, config, pr
       return '';
     }
   });
+};
+
+/**
+ * Merges `Set-Cookie` header
+ *
+ * @param {string|[string]} setCookie
+ * @param {string|[string]} upstreamSetCookie
+ * @returns {[string]}
+ *
+ * @api private
+ */
+common.mergeSetCookie = function mergeCookie(setCookie, upstreamSetCookie) {
+  var existingCookieArray = setCookie || [],
+    upstreamCookieArray = upstreamSetCookie || [];
+
+  if (!Array.isArray(existingCookieArray)) {
+    existingCookieArray = [existingCookieArray]
+  }
+
+  if (!Array.isArray(upstreamCookieArray)) {
+    upstreamCookieArray = [upstreamCookieArray]
+  }
+
+  return [].concat(existingCookieArray, upstreamCookieArray)
 };
 
 /**

--- a/lib/http-proxy/passes/web-outgoing.js
+++ b/lib/http-proxy/passes/web-outgoing.js
@@ -86,6 +86,7 @@ module.exports = { // <--
     var rewriteCookieDomainConfig = options.cookieDomainRewrite,
         rewriteCookiePathConfig = options.cookiePathRewrite,
         preserveHeaderKeyCase = options.preserveHeaderKeyCase,
+        mergeCookiesConfig = options.mergeCookies,
         rawHeaderKeyMap,
         setHeader = function(key, header) {
           if (header == undefined) return;
@@ -95,6 +96,10 @@ module.exports = { // <--
           if (rewriteCookiePathConfig && key.toLowerCase() === 'set-cookie') {
             header = common.rewriteCookieProperty(header, rewriteCookiePathConfig, 'path');
           }
+          if (mergeCookiesConfig && key.toLowerCase() === 'set-cookie') {
+            header = common.mergeSetCookie(res.getHeader("set-cookie"), header)
+          }
+
           res.setHeader(String(key).trim(), header);
         };
 

--- a/test/lib-http-proxy-passes-web-outgoing-test.js
+++ b/test/lib-http-proxy-passes-web-outgoing-test.js
@@ -261,6 +261,9 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
           // Header names are lower-cased
           this.headers[k.toLowerCase()] = v;
         },
+        getHeader: function (k) {
+          return this.headers[k.toLowerCase()]
+        },
         headers: {}
       };
     });
@@ -403,6 +406,19 @@ describe('lib/http-proxy/passes/web-outgoing.js', function () {
         .to.contain('hello-on-my.old.domain; domain=my.new.domain; path=/');
       expect(this.res.headers['set-cookie'])
         .to.contain('hello-on-my.special.domain; domain=my.special.domain; path=/');
+    });
+
+    it('appends set-cookies header to an existing one', function () {
+      var options = {
+        mergeCookies: true,
+      };
+
+      this.res.setHeader("set-cookie", ['hello; domain=my.domain; path=/']);
+
+      httpProxy.writeHeaders({}, this.res, this.proxyRes, options);
+
+      expect(this.res.headers['set-cookie']).to.be.an(Array);
+      expect(this.res.headers['set-cookie']).to.have.length(3);
     });
   });
 


### PR DESCRIPTION
`mergeCookie` options allow to merge `set-cookie` header form passed request object and from a target response

Test added.
Documentation updated.

**Use Case**:
In the project, I'm working on currently, we are using `Express-Gateway` (https://github.com/ExpressGateway/express-gateway) as a single entry point for a set of microservices.
`Express-Gateway` uses `http-proxy` when proxeing requests to a destination service. 
In the gateway we have to setup a cookie with CSRF token.
But some endpoints of our microservices setups it's own cookies and in this case all cookies, that has been setuped in gateway wipes out by cookies from a microservice response.

Raw example:
```
"use strict";

const http = require("http");
const httpProxy = require("http-proxy");
const proxy = httpProxy.createProxyServer({});

const gateway = http.createServer((req, res) => {
  res.setHeader('set-cookie', ["gateway=true; Path=/"]);
  proxy.web(req, res, {target: "http://localhost:3002"});
});

gateway.listen(3003);

const backend = http.createServer((req, res) => {
  res.setHeader("set-cookie", ["backend=true; Path=/", "another_backend_cookie=true; Path=/"]);
  res.end("OK");
});

backend.listen(3002);
```

Curl:
```
$ curl -v http://localhost:3003
* Rebuilt URL to: http://localhost:3003/
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 3003 (#0)
> GET / HTTP/1.1
> Host: localhost:3003
> User-Agent: curl/7.61.1
> Accept: */*
> 
< HTTP/1.1 200 OK
< set-cookie: backend=true; Path=/
< set-cookie: another_backend_cookie=true; Path=/
< date: Mon, 14 Jan 2019 12:24:27 GMT
< connection: close
< content-length: 2
< 
* Closing connection 0
OK
```

By this pull-request I want to add one more option that will instruct proxy-server to merge `set-cookie` header instead of overwriting it.
Existing behaviour remains the same.
