### PR TITLE
Add x-forwarded-host header to websocket connections

### DIFF
--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -64,6 +64,8 @@ module.exports = {
         (req.headers['x-forwarded-' + header] ? ',' : '') +
         values[header];
     });
+
+    req.headers['x-forwarded-host'] = req.headers['x-forwarded-host'] || req.headers['host'] || '';
   },
 
   /**

--- a/test/lib-http-proxy-passes-web-incoming-test.js
+++ b/test/lib-http-proxy-passes-web-incoming-test.js
@@ -68,6 +68,7 @@ describe('lib/http-proxy/passes/web.js', function() {
       expect(stubRequest.headers['x-forwarded-for']).to.be('192.168.1.2');
       expect(stubRequest.headers['x-forwarded-port']).to.be('8080');
       expect(stubRequest.headers['x-forwarded-proto']).to.be('http');
+      expect(stubRequest.headers['x-forwarded-host']).to.be('192.168.1.2:8080');
     });
   });
 });

--- a/test/lib-http-proxy-passes-ws-incoming-test.js
+++ b/test/lib-http-proxy-passes-ws-incoming-test.js
@@ -96,6 +96,7 @@ describe('lib/http-proxy/passes/ws-incoming.js', function () {
       expect(stubRequest.headers['x-forwarded-for']).to.be('192.168.1.2');
       expect(stubRequest.headers['x-forwarded-port']).to.be('8080');
       expect(stubRequest.headers['x-forwarded-proto']).to.be('ws');
+      expect(stubRequest.headers['x-forwarded-host']).to.be('192.168.1.2:8080');
     });
 
     it('set the correct x-forwarded-* headers from req.socket', function () {
@@ -115,6 +116,7 @@ describe('lib/http-proxy/passes/ws-incoming.js', function () {
       expect(stubRequest.headers['x-forwarded-for']).to.be('192.168.1.3');
       expect(stubRequest.headers['x-forwarded-port']).to.be('8181');
       expect(stubRequest.headers['x-forwarded-proto']).to.be('wss');
+      expect(stubRequest.headers['x-forwarded-host']).to.be('192.168.1.3:8181');
     });
   });
 });


### PR DESCRIPTION
Currently `x-forwarded-{for, port, proto}` are sent on websockets, but not `host`.

Also there was no test for `x-forwarded-host` on web connections.