### PR TITLE
feat onProxyReqWs async handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,8 +513,26 @@ data.
     });
     proxy.web(req, res, option);
 
+```
+
+
+### Modify websockets' proxy request with asynchronous handler
+
+If you want to modify a websockets request with asynchronous hadnler, `proxyReqWs` provides special callback argument named `asyncContext` which gets a single async callback that can return a promise.
+The request would be proxied once the promise is resolved.
+
+```js 
+
+onProxyReqWs: (proxyReq, req, socket, options, head, asyncContext) =>
+      asyncContext(async () => {
+        // code ...
+        const result = await anyAsyncOperation()
+        // code ...
+        proxyReq.setHeader('key', result)
+      }),
 
 ```
+ 
 
 #### ProxyTable API
 

--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ data.
 ```
 
 
-### Modify websockets' proxy request with asynchronous handler
+#### Modify websockets' proxy request with asynchronous handler
 
 If you want to modify a websockets request with asynchronous hadnler, `proxyReqWs` provides special callback argument named `asyncContext` which gets a single async callback that can return a promise.
 The request would be proxied once the promise is resolved.

--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -105,7 +105,17 @@ module.exports = {
     );
 
     // Enable developers to modify the proxyReq before headers are sent
-    if (server) { server.emit('proxyReqWs', proxyReq, req, socket, options, head); }
+    if (server) {
+      // Provide the event listener a way to communicate back a promise to signal when its done any async handling
+      const asyncDonePromiseWrapper = {}
+      
+      server.emit('proxyReqWs', proxyReq, req, socket, options, head, asyncDonePromiseWrapper);
+        
+      // If event listener fulfilled a promise, then wait for its completion before we continute
+      if (asyncDonePromiseWrapper.donePromise) {
+        await asyncDonePromiseWrapper.donePromise
+      }
+    }
 
     // Error Handler
     proxyReq.on('error', onOutgoingError);

--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -106,14 +106,16 @@ module.exports = {
 
     // Enable developers to modify the proxyReq before headers are sent
     if (server) {
-      // Provide the event listener a way to communicate back a promise to signal when its done any async handling
-      const asyncDonePromiseWrapper = {}
-      
-      server.emit('proxyReqWs', proxyReq, req, socket, options, head, asyncDonePromiseWrapper);
-        
-      // If event listener fulfilled a promise, then wait for its completion before we continute
-      if (asyncDonePromiseWrapper.donePromise) {
-        await asyncDonePromiseWrapper.donePromise
+      // Provides a way for the event handler to communicate back to the emitter when it finishes its async handling
+      let asyncHandler
+      const asyncContext = (callback) => {
+        asyncHandler = callback
+      }
+
+      server.emit('proxyReqWs', proxyReq, req, socket, options, head, asyncContext);
+
+      if (asyncHandler) {
+        await asyncHandler()
       }
     }
 

--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -76,7 +76,7 @@ module.exports = {
    *
    * @api private
    */
-  stream : function stream(req, socket, options, head, server, clb) {
+  stream : async function stream(req, socket, options, head, server, clb) {
 
     var createHttpHeader = function(line, headers) {
       return Object.keys(headers).reduce(function (head, key) {

--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -104,21 +104,7 @@ module.exports = {
       common.setupOutgoing(options.ssl || {}, options, req)
     );
 
-    // Enable developers to modify the proxyReq before headers are sent
-    if (server) {
-      // Provides a way for the event handler to communicate back to the emitter when it finishes its async handling
-      let asyncHandler
-      const asyncContext = (callback) => {
-        asyncHandler = callback
-      }
-
-      server.emit('proxyReqWs', proxyReq, req, socket, options, head, asyncContext);
-
-      if (asyncHandler) {
-        await asyncHandler()
-      }
-    }
-
+    // It is important to register the event listeners of proxyReq before the first await, so we don't have small period of time in which we lose emitted events
     // Error Handler
     proxyReq.on('error', onOutgoingError);
     proxyReq.on('response', function (res) {
@@ -159,8 +145,23 @@ module.exports = {
       server.emit('open', proxySocket);
       server.emit('proxySocket', proxySocket);  //DEPRECATED.
     });
+      
+    // Enable developers to modify the proxyReq before headers are sent
+    if (server) {
+      // Provides a way for the event handler to communicate back to the emitter when it finishes its async handling
+      let asyncHandler
+      const asyncContext = (callback) => {
+        asyncHandler = callback
+      }
 
-    return proxyReq.end(); // XXX: CHECK IF THIS IS THIS CORRECT
+      server.emit('proxyReqWs', proxyReq, req, socket, options, head, asyncContext);
+
+      if (asyncHandler) {
+        await asyncHandler()
+      }
+    }
+      
+    proxyReq.end();
 
     function onOutgoingError(err) {
       if (clb) {


### PR DESCRIPTION
Following issues https://github.com/http-party/node-http-proxy/issues/490 and https://github.com/http-party/node-http-proxy/issues/1403, currently the library does not support async handler for the `proxyReqWs` event for modifying the request before proxying it forward.

This suggested PR solved the problem, without breaking backward compatibility, by introducing a new argument `asyncContext` which is used as follows:

```js 

onProxyReqWs: (proxyReq, req, socket, options, head, asyncContext) =>
      asyncContext(async () => {
        // code ...
        const result = await anyAsyncOperation()
        // code ...
        proxyReq.setHeader('key', result)
      }),

```