### PR TITLE
Option to enable fall-through on 404 error

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -170,7 +170,7 @@ module.exports = {
     proxyReq.on('response', function(proxyRes) {
       if(server) { server.emit('proxyRes', proxyRes, req, res); }
 
-      if(!res.headersSent && !options.selfHandleResponse) {
+      if(!res.headersSent && !options.selfHandleResponse && (proxyRes.statusCode !== 404)) {
         for(var i=0; i < web_o.length; i++) {
           if(web_o[i](req, res, proxyRes, options)) { break; }
         }
@@ -182,7 +182,9 @@ module.exports = {
           if (server) server.emit('end', req, res, proxyRes);
         });
         // We pipe to the response unless its expected to be handled by the user
-        if (!options.selfHandleResponse) proxyRes.pipe(res);
+        if (!options.selfHandleResponse && (proxyRes.statusCode !== 404)) {
+          proxyRes.pipe(res);
+        }
       } else {
         if (server) server.emit('end', req, res, proxyRes);
       }

--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -170,23 +170,25 @@ module.exports = {
     proxyReq.on('response', function(proxyRes) {
       if(server) { server.emit('proxyRes', proxyRes, req, res); }
 
-      if(!res.headersSent && !options.selfHandleResponse && (proxyRes.statusCode !== 404)) {
-        for(var i=0; i < web_o.length; i++) {
-          if(web_o[i](req, res, proxyRes, options)) { break; }
+      if (!(options.fallthrough === true && proxyRes.statusCode === 404)) {
+        if(!res.headersSent && !options.selfHandleResponse) {
+          for(var i=0; i < web_o.length; i++) {
+            if(web_o[i](req, res, proxyRes, options)) { break; }
+          }
         }
-      }
 
-      if (!res.finished) {
-        // Allow us to listen when the proxy has completed
-        proxyRes.on('end', function () {
+        if (!res.finished) {
+          // Allow us to listen when the proxy has completed
+          proxyRes.on('end', function () {
+            if (server) server.emit('end', req, res, proxyRes);
+          });
+          // We pipe to the response unless its expected to be handled by the user
+          if (!options.selfHandleResponse) {
+            proxyRes.pipe(res);
+          }
+        } else {
           if (server) server.emit('end', req, res, proxyRes);
-        });
-        // We pipe to the response unless its expected to be handled by the user
-        if (!options.selfHandleResponse && (proxyRes.statusCode !== 404)) {
-          proxyRes.pipe(res);
         }
-      } else {
-        if (server) server.emit('end', req, res, proxyRes);
       }
     });
   }


### PR DESCRIPTION
## Use case: 

  - I’m proxying an app (Hugo)
  - If a URL does not exist there, I want to serve it from an older version of the site

I’ve modified [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware) to enable it to fall-through to the middleware chain (see [WIP PR](https://github.com/chimurai/http-proxy-middleware/pull/390), which depends on this one) when it encounters a 404 but without this PR, node-http-proxy already writes out the headers and so we cannot serve the fallback content.

Further context: https://github.com/chimurai/http-proxy-middleware/issues/248#

## Summary of merge request

  - Add `fallthrough` option to the context. If present, 404 responses from the target will not be handled by node-http-proxy so that they can fall through to the middleware chain by the consumer.