### PR TITLE
adjust web-icoming handling of https protocol checks

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -108,7 +108,7 @@ module.exports = {
 
     if(options.forward) {
       // If forward enable, so just pipe the request
-      var forwardReq = (options.forward.protocol === 'https:' ? https : http).request(
+      var forwardReq = (common.isSSL.test(options.forward.protocol) ? https : http).request(
         common.setupOutgoing(options.ssl || {}, options, req, 'forward')
       );
 
@@ -123,7 +123,7 @@ module.exports = {
     }
 
     // Request initalization
-    var proxyReq = (options.target.protocol === 'https:' ? https : http).request(
+    var proxyReq = (common.isSSL.test(options.target.protocol) ? https : http).request(
       common.setupOutgoing(options.ssl || {}, options, req)
     );
 


### PR DESCRIPTION
  - inconsistency between regex check and === 'https:' resulted in
    mismatch of secure port and protocol in common.setupOutgoing

https://github.com/http-party/node-http-proxy/issues/1418