### PR TITLE
fix: check if socket is destroyed before writing to it

### DIFF
--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -111,7 +111,7 @@ module.exports = {
     proxyReq.on('error', onOutgoingError);
     proxyReq.on('response', function (res) {
       // if upgrade event isn't going to happen, close the socket
-      if (!res.upgrade) {
+      if (!res.upgrade && !socket.destroyed) {
         socket.write(createHttpHeader('HTTP/' + res.httpVersion + ' ' + res.statusCode + ' ' + res.statusMessage, res.headers));
         res.pipe(socket);
       }


### PR DESCRIPTION
Fixes #1432 

`net_socket.destroyed` appears to exist as of at least Node 6.0.0 :+1: