### PR TITLE
Fix socket read error when websocket upgrade failed

### DIFF
--- a/lib/http-proxy/passes/ws-incoming.js
+++ b/lib/http-proxy/passes/ws-incoming.js
@@ -113,7 +113,7 @@ module.exports = {
       // if upgrade event isn't going to happen, close the socket
       if (!res.upgrade) {
         socket.write(createHttpHeader('HTTP/' + res.httpVersion + ' ' + res.statusCode + ' ' + res.statusMessage, res.headers));
-        res.pipe(socket);
+        res.pipe(socket).on('error', onOutgoingError);
       }
     });
 


### PR DESCRIPTION

WebSocket proxy will throw below exception when target server restarting(target nginx default return http 502 response at current time).

```

Proxying websocket to /rest/realtime
events.js:298
      throw er; // Unhandled 'error' event
      ^
Error: read ECONNRESET
    at TLSWrap.onStreamRead (internal/stream_base_commons.js:205:27)
Emitted 'error' event on TLSSocket instance at:
    at errorOrDestroy (internal/streams/destroy.js:108:12)
    at TLSSocket.onerror (_stream_readable.js:746:7)
    at TLSSocket.emit (events.js:321:20)
    at emitErrorNT (internal/streams/destroy.js:92:8)
    at emitErrorAndCloseNT (internal/streams/destroy.js:60:3)
    at processTicksAndRejections (internal/process/task_queues.js:84:21) {
  errno: 'ECONNRESET',
  code: 'ECONNRESET',
  syscall: 'read'
}

```

BTW, If cause by websocket, i think the reason for this is the same as the issue https://github.com/http-party/node-http-proxy/issues/1017 。  
