### PR TITLE
Add support for follow-redirects options

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,17 @@ proxyServer.listen(8015);
 *  **headers**: object with extra headers to be added to target requests.
 *  **proxyTimeout**: timeout (in millis) for outgoing proxy requests
 *  **timeout**: timeout (in millis) for incoming requests
-*  **followRedirects**: true/false, Default: false - specify whether you want to follow redirects
+*  **followRedirects**: specify whether you want to follow redirects. Possible values:
+   * `false` (default): do not follow redirects
+   * `true`: follow redirects and use default options
+   * Object: specify options for following redirects.
+     For example:
+     ```
+     followRedirects: {
+        maxRedirects: 10,
+        maxBodyLength: 20 * 1024 * 1024
+     }
+     ```
 *  **selfHandleResponse** true/false, if set to true, none of the webOutgoing passes are called and it's your responsibility to appropriately return the response by listening and acting on the `proxyRes` event
 *  **buffer**: stream of data to send as the request body.  Maybe you have some middleware that consumes the request stream before proxying it on e.g.  If you read the body of a request into a field called 'req.rawbody' you could restream this field in the buffer option:
 

--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -102,6 +102,11 @@ module.exports = {
     // And we begin!
     server.emit('start', req, res, options.target || options.forward);
 
+    if (options.followRedirects) {
+      followRedirects.maxRedirects = options.followRedirects.maxRedirects || followRedirects.maxRedirects;
+      followRedirects.maxBodyLength = options.followRedirects.maxBodyLength || followRedirects.maxBodyLength;
+    }
+
     var agents = options.followRedirects ? followRedirects : nativeAgents;
     var http = agents.http;
     var https = agents.https;


### PR DESCRIPTION
ISSUE: https://github.com/http-party/node-http-proxy/pull/1440

follow-redirects, one of the project dependencies changed their API in the past (in v1.3.0). It introduced some new options and changed the defaults for them. Due to that fact we struggle to use the followRedirects option, because by default we cannot do that for requests bigger than 10MB. This request allows to change those defaults.