### PR TITLE
Run Travis CI against active versions of Node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - "6"
-  - "8"
   - "10"
+  - "12"
 script:
   - npm test
 after_success:


### PR DESCRIPTION
Apparently tests are failing due to the fact that the code does not support node 6 anymore (spread operator). I think it makes more sense to run tests against the active versions only, which are at the moment 10 and 12. Previous versions reached EOL. See here:
https://github.com/nodejs/Release 