### PR TITLE
Skip sending the proxyReq event when the expect header is present

### DIFF
--- a/lib/http-proxy/passes/web-incoming.js
+++ b/lib/http-proxy/passes/web-incoming.js
@@ -129,7 +129,9 @@ module.exports = {
 
     // Enable developers to modify the proxyReq before headers are sent
     proxyReq.on('socket', function(socket) {
-      if(server) { server.emit('proxyReq', proxyReq, req, res, options); }
+      if(server && !proxyReq.getHeader('expect')) {
+        server.emit('proxyReq', proxyReq, req, res, options);
+      }
     });
 
     // allow outgoing socket to timeout so that we could

--- a/test/lib-http-proxy-passes-web-incoming-test.js
+++ b/test/lib-http-proxy-passes-web-incoming-test.js
@@ -126,6 +126,50 @@ describe('#createProxyServer.web() using own http server', function () {
     http.request('http://127.0.0.1:8081', function() {}).end();
   });
 
+  it('should skip proxyReq event when handling a request with header "expect: 100-continue" [https://www.npmjs.com/advisories/1486]', function (done) {
+    var proxy = httpProxy.createProxyServer({
+      target: 'http://127.0.0.1:8080',
+    });
+
+    proxy.on('proxyReq', function(proxyReq, req, res, options) {
+      proxyReq.setHeader('X-Special-Proxy-Header', 'foobar');
+    });
+
+    function requestHandler(req, res) {
+      proxy.web(req, res);
+    }
+
+    var proxyServer = http.createServer(requestHandler);
+
+    var source = http.createServer(function(req, res) {
+      source.close();
+      proxyServer.close();
+      expect(req.headers['x-special-proxy-header']).to.not.eql('foobar');
+      done();
+    });
+
+    proxyServer.listen('8081');
+    source.listen('8080');
+
+    const postData = ''.padStart(10025, 'x');
+
+    const postOptions = {
+      hostname: '127.0.0.1',
+      port: 8081,
+      path: '/',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Length': Buffer.byteLength(postData),
+        'expect': '100-continue'
+      }
+    };
+
+    const req = http.request(postOptions, function() {});
+    req.write(postData);
+    req.end();
+  });
+
   it('should proxy the request and handle error via callback', function(done) {
     var proxy = httpProxy.createProxyServer({
       target: 'http://127.0.0.1:8080'

--- a/test/lib-http-proxy-passes-web-incoming-test.js
+++ b/test/lib-http-proxy-passes-web-incoming-test.js
@@ -151,7 +151,7 @@ describe('#createProxyServer.web() using own http server', function () {
     proxyServer.listen('8081');
     source.listen('8080');
 
-    const postData = ''.padStart(10025, 'x');
+    const postData = ''.padStart(1025, 'x');
 
     const postOptions = {
       hostname: '127.0.0.1',


### PR DESCRIPTION
Hotfix for https://www.npmjs.com/advisories/1486

Expecting build error due to Node 6.  Waiting for https://github.com/http-party/node-http-proxy/pull/1397  to be merged to have a clean CI build.